### PR TITLE
fix: do not swallow deserialization exceptions

### DIFF
--- a/src/main/java/net/ravendb/client/documents/session/EntityToJson.java
+++ b/src/main/java/net/ravendb/client/documents/session/EntityToJson.java
@@ -195,7 +195,7 @@ public class EntityToJson {
 
             return entity;
         } catch (Exception e) {
-            throw new IllegalStateException("Could not convert document " + id + " to entity of type " + entityClass);
+            throw new IllegalStateException("Could not convert document " + id + " to entity of type " + entityClass, e);
         }
     }
 }


### PR DESCRIPTION
Append original cause to the IllegalStateException. This makes the behaviour consistent with the `public Object convertToEntity(Class entityType, String id, ObjectNode document)` overload. 