### PR TITLE
feature: add buffer size to SubscriptionWorkerOptions

### DIFF
--- a/src/main/java/net/ravendb/client/documents/subscriptions/SubscriptionWorker.java
+++ b/src/main/java/net/ravendb/client/documents/subscriptions/SubscriptionWorker.java
@@ -179,8 +179,8 @@ public class SubscriptionWorker<T> implements CleanCloseable {
 
         _tcpClient = TcpUtils.connect(command.getResult().getUrl(), command.getResult().getCertificate(), _store.getCertificate());
         _tcpClient.setTcpNoDelay(true);
-        _tcpClient.setSendBufferSize(32 * 1024);
-        _tcpClient.setReceiveBufferSize(4096);
+        _tcpClient.setSendBufferSize(_options.getSendBufferSize());
+        _tcpClient.setReceiveBufferSize(_options.getSendBufferSize());
 
         String databaseName = ObjectUtils.firstNonNull(_dbName, _store.getDatabase());
 

--- a/src/main/java/net/ravendb/client/documents/subscriptions/SubscriptionWorkerOptions.java
+++ b/src/main/java/net/ravendb/client/documents/subscriptions/SubscriptionWorkerOptions.java
@@ -2,6 +2,7 @@ package net.ravendb.client.documents.subscriptions;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.net.Socket;
 import java.time.Duration;
 
 /**
@@ -16,12 +17,16 @@ public class SubscriptionWorkerOptions {
     private int maxDocsPerBatch;
     private Duration maxErroneousPeriod;
     private boolean closeWhenNoDocsLeft;
+    private int receiveBufferSize;
+    private int sendBufferSize;
 
     private SubscriptionWorkerOptions() {
         strategy = SubscriptionOpeningStrategy.OPEN_IF_FREE;
         maxDocsPerBatch = 4096;
         timeToWaitBeforeConnectionRetry = Duration.ofSeconds(5);
         maxErroneousPeriod = Duration.ofMinutes(5);
+        receiveBufferSize = 32 * 1024;
+        sendBufferSize = 32 * 1024;
     }
 
     /**
@@ -132,5 +137,37 @@ public class SubscriptionWorkerOptions {
      */
     public void setCloseWhenNoDocsLeft(boolean closeWhenNoDocsLeft) {
         this.closeWhenNoDocsLeft = closeWhenNoDocsLeft;
+    }
+
+    /**
+     * @return Receive buffer size for the underlying {@link Socket}. Default: 32 kB
+     */
+    public int getReceiveBufferSize() {
+        return receiveBufferSize;
+    }
+
+    /**
+     * Set receive buffer size for the underlying {@link Socket}. See {@link Socket#setReceiveBufferSize(int)}.
+     * Optimal size is a trade-off between memory and (size of the link in B/s) x (round trip delay in seconds)
+     * @param receiveBufferSize receive buffer size for the underlying {@link Socket}. Default: 32 kB
+     */
+    public void setReceiveBufferSize(int receiveBufferSize) {
+        this.receiveBufferSize = receiveBufferSize;
+    }
+
+    /**
+     * @return Send buffer size for the underlying {@link Socket}. Default: 32 kB
+     */
+    public int getSendBufferSize() {
+        return sendBufferSize;
+    }
+
+    /**
+     * Set send buffer size for the underlying {@link Socket}. See {@link Socket#setSendBufferSize(int)}.
+     * Optimal size is a trade-off between memory and (size of the link in B/s) x (round trip delay in seconds)
+     * @param sendBufferSize receive buffer size for the underlying {@link Socket}. Default: 32 kB
+     */
+    public void setSendBufferSize(int sendBufferSize) {
+        this.sendBufferSize = sendBufferSize;
     }
 }


### PR DESCRIPTION
We've had abysmally slow subscription performance when testing with a (local!!) RavenDB instance and a subscription running on the same host on linux. Performance was fine with a similar setup on OS X. So we did some tracing using wireshark and discovered that under linux the TCP stream for the subscription was very slowly tickling along. Increasing the receive buffer size of the socket improved performance by a factor > 1000x. 

It makes sense to have this user-configurable so users can tune this to their target environment (i.e. latency / link speed / memory consumption). 