### PR TITLE
V5.2 fix emoji

### DIFF
--- a/src/main/java/net/ravendb/client/documents/commands/CreateSubscriptionCommand.java
+++ b/src/main/java/net/ravendb/client/documents/commands/CreateSubscriptionCommand.java
@@ -45,7 +45,7 @@ public class CreateSubscriptionCommand extends RavenCommand<CreateSubscriptionRe
 
         HttpPut request = new HttpPut();
         request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-            try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+            try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                 generator.getCodec().writeValue(generator, _options);
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/documents/commands/ExplainQueryCommand.java
+++ b/src/main/java/net/ravendb/client/documents/commands/ExplainQueryCommand.java
@@ -64,7 +64,7 @@ public class ExplainQueryCommand extends RavenCommand<ExplainQueryCommand.Explai
         HttpPost request = new HttpPost();
 
         request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-            try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+            try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                 JsonExtensions.writeIndexQuery(generator, _conventions, _indexQuery);
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/documents/commands/GetDocumentsCommand.java
+++ b/src/main/java/net/ravendb/client/documents/commands/GetDocumentsCommand.java
@@ -255,7 +255,7 @@ public class GetDocumentsCommand extends RavenCommand<GetDocumentsResult> {
             ObjectMapper mapper = JsonExtensions.getDefaultMapper();
 
             httpPost.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.writeStartObject();
                     generator.writeFieldName("Ids");
                     generator.writeStartArray();

--- a/src/main/java/net/ravendb/client/documents/commands/GetDocumentsCommand.java
+++ b/src/main/java/net/ravendb/client/documents/commands/GetDocumentsCommand.java
@@ -23,6 +23,8 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.ContentType;
 
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 public class GetDocumentsCommand extends RavenCommand<GetDocumentsResult> {
@@ -255,7 +257,7 @@ public class GetDocumentsCommand extends RavenCommand<GetDocumentsResult> {
             ObjectMapper mapper = JsonExtensions.getDefaultMapper();
 
             httpPost.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
+                try (JsonGenerator generator = JsonExtensions.getDefaultMapper().createGenerator(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8))) {
                     generator.writeStartObject();
                     generator.writeFieldName("Ids");
                     generator.writeStartArray();

--- a/src/main/java/net/ravendb/client/documents/commands/PutDocumentCommand.java
+++ b/src/main/java/net/ravendb/client/documents/commands/PutDocumentCommand.java
@@ -41,7 +41,7 @@ public class PutDocumentCommand extends RavenCommand<PutResult> {
         HttpPut request = new HttpPut();
 
         request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-            try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+            try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                 generator.writeTree(_document);
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/documents/commands/QueryCommand.java
+++ b/src/main/java/net/ravendb/client/documents/commands/QueryCommand.java
@@ -62,7 +62,7 @@ public class QueryCommand extends RavenCommand<QueryResult> {
 
         HttpPost request = new HttpPost();
         request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-            try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+            try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                 JsonExtensions.writeIndexQuery(generator, _session.getConventions(), _indexQuery);
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/documents/commands/QueryStreamCommand.java
+++ b/src/main/java/net/ravendb/client/documents/commands/QueryStreamCommand.java
@@ -41,7 +41,7 @@ public class QueryStreamCommand extends RavenCommand<StreamResultResponse> {
         HttpPost request = new HttpPost();
 
         request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-            try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+            try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                 JsonExtensions.writeIndexQuery(generator, _conventions, _indexQuery);
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/documents/commands/UpdateSubscriptionCommand.java
+++ b/src/main/java/net/ravendb/client/documents/commands/UpdateSubscriptionCommand.java
@@ -29,7 +29,7 @@ public class UpdateSubscriptionCommand extends RavenCommand<UpdateSubscriptionRe
 
         HttpPost request = new HttpPost();
         request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-            try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+            try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                 generator.getCodec().writeValue(generator, _options);
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/documents/commands/batches/SingleNodeBatchCommand.java
+++ b/src/main/java/net/ravendb/client/documents/commands/batches/SingleNodeBatchCommand.java
@@ -86,7 +86,7 @@ public class SingleNodeBatchCommand extends RavenCommand<BatchCommandResult> imp
         HttpPost request = new HttpPost();
 
         request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-            try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+            try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                 if (_supportsAtomicWrites == null || node.isSupportsAtomicClusterWrites() != _supportsAtomicWrites) {
                     _supportsAtomicWrites = node.isSupportsAtomicClusterWrites();
                 }
@@ -102,7 +102,7 @@ public class SingleNodeBatchCommand extends RavenCommand<BatchCommandResult> imp
                 } else {
                     for (ICommandData command : _commands) {
                         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                        try (JsonGenerator itemGenerator = mapper.createGenerator(baos)) {
+                        try (JsonGenerator itemGenerator = createSafeJsonGenerator(baos)) {
                             command.serialize(itemGenerator, _conventions);
                         }
 

--- a/src/main/java/net/ravendb/client/documents/commands/multiGet/MultiGetCommand.java
+++ b/src/main/java/net/ravendb/client/documents/commands/multiGet/MultiGetCommand.java
@@ -108,7 +108,7 @@ public class MultiGetCommand extends RavenCommand<List<GetResponse>> implements 
         ObjectMapper mapper = JsonExtensions.getDefaultMapper();
 
         request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-            try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+            try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
 
                 generator.writeStartObject();
 

--- a/src/main/java/net/ravendb/client/documents/operations/CompactDatabaseOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/CompactDatabaseOperation.java
@@ -57,7 +57,7 @@ public class CompactDatabaseOperation implements IServerOperation<OperationIdRes
             HttpPost request = new HttpPost();
 
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = JsonExtensions.getDefaultMapper().getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.writeTree(_compactSettings);
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/documents/operations/DeleteByQueryOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/DeleteByQueryOperation.java
@@ -82,7 +82,7 @@ public class DeleteByQueryOperation implements IOperation<OperationIdResult> {
 
             HttpDeleteWithEntity request = new HttpDeleteWithEntity();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     JsonExtensions.writeIndexQuery(generator, _conventions, _queryToDelete);
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/documents/operations/PatchByQueryOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/PatchByQueryOperation.java
@@ -75,7 +75,7 @@ public class PatchByQueryOperation implements IOperation<OperationIdResult> {
 
             HttpPatch request = new HttpPatch();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.writeStartObject();
 
                     generator.writeFieldName("Query");

--- a/src/main/java/net/ravendb/client/documents/operations/PatchOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/PatchOperation.java
@@ -164,7 +164,7 @@ public class PatchOperation implements IOperation<PatchResult> {
 
             HttpPatch request = new HttpPatch();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.writeStartObject();
 
                     generator.writeFieldName("Patch");

--- a/src/main/java/net/ravendb/client/documents/operations/ToggleDatabasesStateOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/ToggleDatabasesStateOperation.java
@@ -77,7 +77,7 @@ public class ToggleDatabasesStateOperation implements IServerOperation<DisableDa
 
             HttpPost request = new HttpPost();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     ObjectNode config = mapper.valueToTree(_parameters);
                     generator.writeTree(config);
                 } catch (IOException e) {

--- a/src/main/java/net/ravendb/client/documents/operations/analyzers/PutAnalyzersOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/analyzers/PutAnalyzersOperation.java
@@ -61,7 +61,7 @@ public class PutAnalyzersOperation implements IVoidMaintenanceOperation {
 
             HttpPut request = new HttpPut();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.writeStartObject();
                     generator.writeFieldName("Analyzers");
                     generator.writeStartArray();

--- a/src/main/java/net/ravendb/client/documents/operations/attachments/GetAttachmentOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/attachments/GetAttachmentOperation.java
@@ -77,7 +77,7 @@ public class GetAttachmentOperation implements IOperation<CloseableAttachmentRes
                 HttpPost request = new HttpPost();
 
                 request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                    try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                    try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                         generator.writeStartObject();
                         generator.writeStringField("Type", "Revision");
                         generator.writeStringField("ChangeVector", _changeVector);

--- a/src/main/java/net/ravendb/client/documents/operations/attachments/GetAttachmentsOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/attachments/GetAttachmentsOperation.java
@@ -63,7 +63,7 @@ public class GetAttachmentsOperation implements IOperation<CloseableAttachmentsR
 
             HttpPost request = new HttpPost();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.writeStartObject();
 
                     generator.writeStringField("AttachmentType", SharpEnum.value(_type));

--- a/src/main/java/net/ravendb/client/documents/operations/backups/BackupOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/backups/BackupOperation.java
@@ -61,7 +61,7 @@ public class BackupOperation implements IMaintenanceOperation<OperationIdResult>
 
             HttpPost request = new HttpPost();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     mapper.writeValue(generator, _backupConfiguration);
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/documents/operations/backups/RestoreBackupOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/backups/RestoreBackupOperation.java
@@ -68,7 +68,7 @@ public class RestoreBackupOperation implements IServerOperation<OperationIdResul
 
             HttpPost request = new HttpPost();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     ObjectNode config = mapper.valueToTree(_restoreConfiguration);
                     generator.writeTree(config);
                 } catch (IOException e) {

--- a/src/main/java/net/ravendb/client/documents/operations/backups/UpdatePeriodicBackupOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/backups/UpdatePeriodicBackupOperation.java
@@ -49,7 +49,7 @@ public class UpdatePeriodicBackupOperation implements IMaintenanceOperation<Upda
 
             HttpPost request = new HttpPost();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     ObjectNode config = mapper.valueToTree(_configuration);
                     generator.writeTree(config);
                 } catch (IOException e) {

--- a/src/main/java/net/ravendb/client/documents/operations/compareExchange/PutCompareExchangeValueOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/compareExchange/PutCompareExchangeValueOperation.java
@@ -96,7 +96,7 @@ public class PutCompareExchangeValueOperation<T> implements IOperation<CompareEx
 
             HttpPut httpPut = new HttpPut();
             httpPut.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.writeTree(json);
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/documents/operations/connectionStrings/PutConnectionStringOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/connectionStrings/PutConnectionStringOperation.java
@@ -53,7 +53,7 @@ public class PutConnectionStringOperation<T extends ConnectionString> implements
 
             HttpPut request = new HttpPut();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     ObjectNode config = mapper.valueToTree(_connectionString);
                     generator.writeTree(config);
                 } catch (IOException e) {

--- a/src/main/java/net/ravendb/client/documents/operations/counters/CounterBatchOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/counters/CounterBatchOperation.java
@@ -47,7 +47,7 @@ public class CounterBatchOperation implements IOperation<CountersDetail> {
             HttpPost request = new HttpPost();
 
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     _counterBatch.serialize(generator);
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/documents/operations/counters/GetCountersOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/counters/GetCountersOperation.java
@@ -140,7 +140,7 @@ public class GetCountersOperation implements IOperation<CountersDetail> {
                 batch.setReplyWithAllNodesValues(_returnFullResults);
 
                 postRequest.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                    try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                    try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                         batch.serialize(generator);
                     } catch (IOException e) {
                         throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/documents/operations/etl/AddEtlOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/etl/AddEtlOperation.java
@@ -49,7 +49,7 @@ public class AddEtlOperation<T extends ConnectionString> implements IMaintenance
 
             HttpPut request = new HttpPut();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     ObjectNode config = mapper.valueToTree(_configuration);
                     generator.writeTree(config);
                 } catch (IOException e) {

--- a/src/main/java/net/ravendb/client/documents/operations/etl/ResetEtlOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/etl/ResetEtlOperation.java
@@ -69,7 +69,7 @@ public class ResetEtlOperation implements IVoidMaintenanceOperation {
 
             HttpResetWithEntity request = new HttpResetWithEntity();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.writeStartObject();
                     generator.writeEndObject();
                 } catch (IOException e) {

--- a/src/main/java/net/ravendb/client/documents/operations/etl/UpdateEtlOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/etl/UpdateEtlOperation.java
@@ -53,7 +53,7 @@ public class UpdateEtlOperation<T extends ConnectionString> implements IMaintena
 
             HttpPut request = new HttpPut();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     ObjectNode config = mapper.valueToTree(_configuration);
                     generator.writeTree(config);
                 } catch (IOException e) {

--- a/src/main/java/net/ravendb/client/documents/operations/expiration/ConfigureExpirationOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/expiration/ConfigureExpirationOperation.java
@@ -53,7 +53,7 @@ public class ConfigureExpirationOperation implements IMaintenanceOperation<Confi
 
             HttpPost request = new HttpPost();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     ObjectNode config = mapper.valueToTree(_configuration);
                     generator.writeTree(config);
                 } catch (IOException e) {

--- a/src/main/java/net/ravendb/client/documents/operations/indexes/IndexHasChangedOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/indexes/IndexHasChangedOperation.java
@@ -54,7 +54,7 @@ public class IndexHasChangedOperation implements IMaintenanceOperation<Boolean> 
             HttpPost request = new HttpPost();
 
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.writeTree(_definition);
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/documents/operations/indexes/PutIndexesOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/indexes/PutIndexesOperation.java
@@ -79,7 +79,7 @@ public class PutIndexesOperation implements IMaintenanceOperation<PutIndexResult
             ObjectMapper mapper = JsonExtensions.getDefaultMapper();
 
             httpPut.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.writeStartObject();
                     generator.writeFieldName("Indexes");
                     generator.writeStartArray();

--- a/src/main/java/net/ravendb/client/documents/operations/indexes/SetIndexesLockOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/indexes/SetIndexesLockOperation.java
@@ -83,7 +83,7 @@ public class SetIndexesLockOperation implements IVoidMaintenanceOperation {
             HttpPost request = new HttpPost();
 
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.writeTree(_parameters);
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/documents/operations/indexes/SetIndexesPriorityOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/indexes/SetIndexesPriorityOperation.java
@@ -69,7 +69,7 @@ public class SetIndexesPriorityOperation implements IVoidMaintenanceOperation {
             HttpPost request = new HttpPost();
 
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.writeTree(_parameters);
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/documents/operations/refresh/ConfigureRefreshOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/refresh/ConfigureRefreshOperation.java
@@ -50,7 +50,7 @@ public class ConfigureRefreshOperation implements IMaintenanceOperation<Configur
 
             HttpPost request = new HttpPost();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.getCodec().writeValue(generator, _configuration);
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/documents/operations/replication/PutPullReplicationAsHubOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/replication/PutPullReplicationAsHubOperation.java
@@ -55,7 +55,7 @@ public class PutPullReplicationAsHubOperation implements IMaintenanceOperation<M
 
             HttpPut request = new HttpPut();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.getCodec().writeValue(generator, _pullReplicationDefinition);
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/documents/operations/replication/RegisterReplicationHubAccessOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/replication/RegisterReplicationHubAccessOperation.java
@@ -68,7 +68,7 @@ public class RegisterReplicationHubAccessOperation implements IVoidMaintenanceOp
 
             HttpPut request = new HttpPut();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.getCodec().writeValue(generator, _access);
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/documents/operations/replication/UpdateExternalReplicationOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/replication/UpdateExternalReplicationOperation.java
@@ -48,7 +48,7 @@ public class UpdateExternalReplicationOperation implements IMaintenanceOperation
 
             HttpPost request = new HttpPost();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.writeStartObject();
                     generator.writeFieldName("Watcher");
 

--- a/src/main/java/net/ravendb/client/documents/operations/replication/UpdatePullReplicationAsSinkOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/replication/UpdatePullReplicationAsSinkOperation.java
@@ -45,7 +45,7 @@ public class UpdatePullReplicationAsSinkOperation implements IMaintenanceOperati
 
             HttpPost request = new HttpPost();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.writeStartObject();
                     generator.writeFieldName("PullReplicationAsSink");
                     generator.getCodec().writeValue(generator, _pullReplication);

--- a/src/main/java/net/ravendb/client/documents/operations/revisions/ConfigureRevisionsOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/revisions/ConfigureRevisionsOperation.java
@@ -51,7 +51,7 @@ public class ConfigureRevisionsOperation implements IMaintenanceOperation<Config
 
             HttpPost request = new HttpPost();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     ObjectNode config = mapper.valueToTree(_configuration);
                     generator.writeTree(config);
                 } catch (IOException e) {

--- a/src/main/java/net/ravendb/client/documents/operations/sorters/PutSortersOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/sorters/PutSortersOperation.java
@@ -59,7 +59,7 @@ public class PutSortersOperation implements IVoidMaintenanceOperation {
 
             HttpPut request = new HttpPut();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.writeStartObject();
                     generator.writeFieldName("Sorters");
                     generator.getCodec().writeValue(generator, _sortersToAdd);

--- a/src/main/java/net/ravendb/client/documents/operations/timeSeries/ConfigureTimeSeriesOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/timeSeries/ConfigureTimeSeriesOperation.java
@@ -53,7 +53,7 @@ public class ConfigureTimeSeriesOperation implements IMaintenanceOperation<Confi
 
             HttpPost request = new HttpPost();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     ObjectNode config = mapper.valueToTree(_configuration);
                     generator.writeTree(config);
                 } catch (IOException e) {

--- a/src/main/java/net/ravendb/client/documents/operations/timeSeries/ConfigureTimeSeriesPolicyOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/timeSeries/ConfigureTimeSeriesPolicyOperation.java
@@ -62,7 +62,7 @@ public class ConfigureTimeSeriesPolicyOperation implements IMaintenanceOperation
             HttpPut request = new HttpPut();
 
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     ObjectNode config = mapper.valueToTree(_configuration);
                     generator.writeTree(config);
                 } catch (IOException e) {

--- a/src/main/java/net/ravendb/client/documents/operations/timeSeries/ConfigureTimeSeriesValueNamesOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/timeSeries/ConfigureTimeSeriesValueNamesOperation.java
@@ -52,7 +52,7 @@ public class ConfigureTimeSeriesValueNamesOperation implements IMaintenanceOpera
             HttpPost request = new HttpPost();
 
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.getCodec().writeValue(generator, _parameters);
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/documents/operations/timeSeries/TimeSeriesBatchOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/timeSeries/TimeSeriesBatchOperation.java
@@ -56,7 +56,7 @@ public class TimeSeriesBatchOperation implements IVoidOperation {
             HttpPost request = new HttpPost();
 
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = JsonExtensions.getDefaultMapper().getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     _operation.serialize(generator, _conventions);
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/documents/operations/transactionsRecording/StartTransactionsRecordingOperation.java
+++ b/src/main/java/net/ravendb/client/documents/operations/transactionsRecording/StartTransactionsRecordingOperation.java
@@ -43,7 +43,7 @@ public class StartTransactionsRecordingOperation implements IVoidMaintenanceOper
 
             HttpPost request = new HttpPost();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.writeStartObject();
                     generator.writeStringField("File", _filePath);
                     generator.writeEndObject();

--- a/src/main/java/net/ravendb/client/documents/session/DocumentSession.java
+++ b/src/main/java/net/ravendb/client/documents/session/DocumentSession.java
@@ -37,6 +37,8 @@ import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -376,7 +378,7 @@ public class DocumentSession extends InMemoryDocumentSessionOperations
             if (stream != null) {
                 try {
                     GetDocumentsResult result = command.getResult();
-                    JsonExtensions.getDefaultMapper().writeValue(stream, result);
+                    JsonExtensions.getDefaultMapper().writeValue(new OutputStreamWriter(stream, StandardCharsets.UTF_8), result);
                 } catch (IOException e) {
                     throw new RuntimeException("Unable to serialize returned value into stream" + e.getMessage(), e);
                 }
@@ -552,7 +554,7 @@ public class DocumentSession extends InMemoryDocumentSessionOperations
             if (stream != null) {
                 try {
                     GetDocumentsResult result = command.getResult();
-                    JsonExtensions.getDefaultMapper().writeValue(stream, result);
+                    JsonExtensions.getDefaultMapper().writeValue(new OutputStreamWriter(stream, StandardCharsets.UTF_8), result);
                 } catch (IOException e) {
                     throw new RuntimeException("Unable to serialize returned value into stream" + e.getMessage(), e);
                 }

--- a/src/main/java/net/ravendb/client/documents/smuggler/DatabaseSmuggler.java
+++ b/src/main/java/net/ravendb/client/documents/smuggler/DatabaseSmuggler.java
@@ -215,7 +215,7 @@ public class DatabaseSmuggler {
 
             HttpPost request = new HttpPost();
             ContentProviderHttpEntity entity = new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.getCodec().writeValue(generator, _options);
                 } catch (IOException e) {
                     throw new RuntimeException(e);
@@ -270,6 +270,7 @@ public class DatabaseSmuggler {
             try {
                 MultipartEntityBuilder entityBuilder = MultipartEntityBuilder.create();
 
+                // TODO: this might corrupt anything that is unicode surrogate pairs since internally uses an OutputStream instead of Writer
                 entityBuilder.addBinaryBody("importOptions", mapper.writeValueAsBytes(_options));
                 InputStreamBody inputStreamBody = new InputStreamBody(_stream, "name");
                 FormBodyPart part = FormBodyPartBuilder.create("file", inputStreamBody)

--- a/src/main/java/net/ravendb/client/documents/subscriptions/SubscriptionWorker.java
+++ b/src/main/java/net/ravendb/client/documents/subscriptions/SubscriptionWorker.java
@@ -236,6 +236,7 @@ public class SubscriptionWorker<T> implements CleanCloseable {
             throw new IllegalStateException(_options.getSubscriptionName() + " : TCP negotiation resulted with an invalid protocol version: " + _supportedFeatures.protocolVersion);
         }
 
+        // TODO: this might corrupt anything that is unicode surrogate pairs since internally uses an OutputStream instead of Writer
         byte[] options = JsonExtensions.getDefaultMapper().writeValueAsBytes(_options);
 
         _tcpClient.getOutputStream().write(options);
@@ -319,6 +320,8 @@ public class SubscriptionWorker<T> implements CleanCloseable {
         dropMsg.setDatabaseName(_dbName);
         dropMsg.setOperationVersion(TcpConnectionHeaderMessage.SUBSCRIPTION_TCP_VERSION);
         dropMsg.setInfo("Couldn't agree on subscription tcp version ours: " + TcpConnectionHeaderMessage.SUBSCRIPTION_TCP_VERSION + " theirs: " + reply.getVersion());
+
+        // TODO: this might corrupt anything that is unicode surrogate pairs since internally uses an OutputStream instead of Writer
         byte[] header = JsonExtensions.getDefaultMapper().writeValueAsBytes(dropMsg);
         _tcpClient.getOutputStream().write(header);
         _tcpClient.getOutputStream().flush();
@@ -565,6 +568,8 @@ public class SubscriptionWorker<T> implements CleanCloseable {
         SubscriptionConnectionClientMessage msg = new SubscriptionConnectionClientMessage();
         msg.setChangeVector(lastReceivedChangeVector);
         msg.setType(SubscriptionConnectionClientMessage.MessageType.ACKNOWLEDGE);
+
+        // TODO: this might corrupt anything that is unicode surrogate pairs since internally uses an OutputStream instead of Writer
         byte[] ack = JsonExtensions.getDefaultMapper().writeValueAsBytes(msg);
         networkStream.getOutputStream().write(ack);
         networkStream.getOutputStream().flush();

--- a/src/main/java/net/ravendb/client/http/RavenCommand.java
+++ b/src/main/java/net/ravendb/client/http/RavenCommand.java
@@ -1,5 +1,6 @@
 package net.ravendb.client.http;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import net.ravendb.client.extensions.HttpExtensions;
 import net.ravendb.client.extensions.JsonExtensions;
@@ -13,9 +14,7 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
+import java.io.*;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -99,6 +98,10 @@ public abstract class RavenCommand<TResult> {
         this.canCacheAggressively = copy.canCacheAggressively;
         this.selectedNodeTag = copy.selectedNodeTag;
         this.responseType = copy.responseType;
+    }
+
+    protected final JsonGenerator createSafeJsonGenerator(OutputStream out) throws IOException {
+       return mapper.createGenerator(new OutputStreamWriter(out, StandardCharsets.UTF_8));
     }
 
     public abstract HttpRequestBase createRequest(ServerNode node, Reference<String> url);

--- a/src/main/java/net/ravendb/client/serverwide/operations/ConfigureRevisionsForConflictsOperation.java
+++ b/src/main/java/net/ravendb/client/serverwide/operations/ConfigureRevisionsForConflictsOperation.java
@@ -62,7 +62,7 @@ public class ConfigureRevisionsForConflictsOperation implements IServerOperation
 
             HttpPost request = new HttpPost();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     ObjectNode config = mapper.valueToTree(_configuration);
                     generator.writeTree(config);
                 } catch (IOException e) {

--- a/src/main/java/net/ravendb/client/serverwide/operations/ModifyConflictSolverOperation.java
+++ b/src/main/java/net/ravendb/client/serverwide/operations/ModifyConflictSolverOperation.java
@@ -70,7 +70,7 @@ public class ModifyConflictSolverOperation implements IServerOperation<ModifySol
             HttpPost request = new HttpPost();
 
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     ConflictSolver solver = new ConflictSolver();
                     solver.setResolveToLatest(_solver._resolveToLatest);
                     solver.setResolveByCollection(_solver._collectionByScript);

--- a/src/main/java/net/ravendb/client/serverwide/operations/ReorderDatabaseMembersOperation.java
+++ b/src/main/java/net/ravendb/client/serverwide/operations/ReorderDatabaseMembersOperation.java
@@ -84,7 +84,7 @@ public class ReorderDatabaseMembersOperation implements IVoidServerOperation {
 
             HttpPost request = new HttpPost();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     ObjectNode config = mapper.valueToTree(_parameters);
                     generator.writeTree(config);
                 } catch (IOException e) {

--- a/src/main/java/net/ravendb/client/serverwide/operations/UpdateUnusedDatabasesOperation.java
+++ b/src/main/java/net/ravendb/client/serverwide/operations/UpdateUnusedDatabasesOperation.java
@@ -51,7 +51,7 @@ public class UpdateUnusedDatabasesOperation implements IVoidServerOperation {
 
             HttpPost request = new HttpPost();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.getCodec().writeValue(generator, _parameters);
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/serverwide/operations/analyzers/PutServerWideAnalyzersOperation.java
+++ b/src/main/java/net/ravendb/client/serverwide/operations/analyzers/PutServerWideAnalyzersOperation.java
@@ -63,7 +63,7 @@ public class PutServerWideAnalyzersOperation implements IVoidServerOperation {
             HttpPut httpPut = new HttpPut();
 
             httpPut.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.writeStartObject();
                     generator.writeFieldName("Analyzers");
                     generator.writeStartArray();

--- a/src/main/java/net/ravendb/client/serverwide/operations/certificates/CreateClientCertificateOperation.java
+++ b/src/main/java/net/ravendb/client/serverwide/operations/certificates/CreateClientCertificateOperation.java
@@ -88,7 +88,7 @@ public class CreateClientCertificateOperation implements IServerOperation<Certif
             HttpPost request = new HttpPost();
 
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.writeStartObject();
 
                     generator.writeStringField("Name", _name);

--- a/src/main/java/net/ravendb/client/serverwide/operations/certificates/EditClientCertificateOperation.java
+++ b/src/main/java/net/ravendb/client/serverwide/operations/certificates/EditClientCertificateOperation.java
@@ -85,7 +85,7 @@ public class EditClientCertificateOperation implements IVoidServerOperation {
             HttpPost request = new HttpPost();
 
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.getCodec().writeValue(generator, definition);
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/serverwide/operations/certificates/PutClientCertificateOperation.java
+++ b/src/main/java/net/ravendb/client/serverwide/operations/certificates/PutClientCertificateOperation.java
@@ -80,7 +80,7 @@ public class PutClientCertificateOperation implements IVoidServerOperation {
             HttpPut request = new HttpPut();
 
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
 
                     generator.writeStartObject();
                     generator.writeStringField("Name", _name);

--- a/src/main/java/net/ravendb/client/serverwide/operations/certificates/ReplaceClusterCertificateOperation.java
+++ b/src/main/java/net/ravendb/client/serverwide/operations/certificates/ReplaceClusterCertificateOperation.java
@@ -59,7 +59,7 @@ public class ReplaceClusterCertificateOperation implements IVoidServerOperation 
 
             HttpPost request = new HttpPost();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.writeStartObject();
                     generator.writeFieldName("Certificate");
                     generator.writeString(Base64.encodeBase64String(_certBytes));

--- a/src/main/java/net/ravendb/client/serverwide/operations/configuration/PutServerWideBackupConfigurationOperation.java
+++ b/src/main/java/net/ravendb/client/serverwide/operations/configuration/PutServerWideBackupConfigurationOperation.java
@@ -61,7 +61,7 @@ public class PutServerWideBackupConfigurationOperation implements IServerOperati
 
             HttpPut request = new HttpPut();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.getCodec().writeValue(generator, _configuration);
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/serverwide/operations/configuration/PutServerWideClientConfigurationOperation.java
+++ b/src/main/java/net/ravendb/client/serverwide/operations/configuration/PutServerWideClientConfigurationOperation.java
@@ -53,7 +53,7 @@ public class PutServerWideClientConfigurationOperation implements IVoidServerOpe
 
             HttpPut request = new HttpPut();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     ObjectNode config = mapper.valueToTree(_configuration);
                     generator.writeTree(config);
                 } catch (IOException e) {

--- a/src/main/java/net/ravendb/client/serverwide/operations/documentsCompression/UpdateDocumentsCompressionConfigurationOperation.java
+++ b/src/main/java/net/ravendb/client/serverwide/operations/documentsCompression/UpdateDocumentsCompressionConfigurationOperation.java
@@ -56,7 +56,7 @@ public class UpdateDocumentsCompressionConfigurationOperation implements IMainte
             HttpPost request = new HttpPost();
 
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.getCodec().writeValue(generator, _documentsCompressionConfiguration);
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/serverwide/operations/logs/SetLogsConfigurationOperation.java
+++ b/src/main/java/net/ravendb/client/serverwide/operations/logs/SetLogsConfigurationOperation.java
@@ -49,7 +49,7 @@ public class SetLogsConfigurationOperation implements IVoidServerOperation {
 
             HttpPost request = new HttpPost();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     ObjectNode config = mapper.valueToTree(_parameters);
                     generator.writeTree(config);
                 } catch (IOException e) {

--- a/src/main/java/net/ravendb/client/serverwide/operations/ongoingTasks/PutServerWideExternalReplicationOperation.java
+++ b/src/main/java/net/ravendb/client/serverwide/operations/ongoingTasks/PutServerWideExternalReplicationOperation.java
@@ -59,7 +59,7 @@ public class PutServerWideExternalReplicationOperation implements IServerOperati
 
             HttpPut request = new HttpPut();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.writeObject(_configuration);
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/serverwide/operations/ongoingTasks/SetDatabasesLockOperation.java
+++ b/src/main/java/net/ravendb/client/serverwide/operations/ongoingTasks/SetDatabasesLockOperation.java
@@ -69,7 +69,7 @@ public class SetDatabasesLockOperation implements IVoidServerOperation {
 
             HttpPost request = new HttpPost();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.getCodec().writeValue(generator, _parameters);
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/net/ravendb/client/serverwide/operations/sorters/PutServerWideSortersOperation.java
+++ b/src/main/java/net/ravendb/client/serverwide/operations/sorters/PutServerWideSortersOperation.java
@@ -62,7 +62,7 @@ public class PutServerWideSortersOperation implements IVoidServerOperation {
 
             HttpPut request = new HttpPut();
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.writeStartObject();
                     generator.writeFieldName("Sorters");
                     generator.writeStartArray();

--- a/src/main/java/net/ravendb/client/serverwide/tcp/TcpNegotiation.java
+++ b/src/main/java/net/ravendb/client/serverwide/tcp/TcpNegotiation.java
@@ -9,6 +9,8 @@ import org.apache.commons.logging.LogFactory;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 
 public class TcpNegotiation {
 
@@ -64,7 +66,7 @@ public class TcpNegotiation {
             logger.info("Send negotiation for " + parameters.getOperation() + " in version " + currentVersion);
         }
 
-        try (JsonGenerator generator =  JsonExtensions.getDefaultMapper().getFactory().createGenerator(stream)) {
+        try (JsonGenerator generator =  JsonExtensions.getDefaultMapper().getFactory().createGenerator(new OutputStreamWriter(stream, StandardCharsets.UTF_8))) {
             generator.configure(JsonGenerator.Feature.AUTO_CLOSE_TARGET, false);
 
             generator.writeStartObject();

--- a/src/test/java/net/ravendb/client/documents/commands/PutDocumentCommandTest.java
+++ b/src/test/java/net/ravendb/client/documents/commands/PutDocumentCommandTest.java
@@ -41,5 +41,36 @@ public class PutDocumentCommandTest extends RemoteTestBase {
             }
         }
     }
+
+    @Test
+    public void canPutDocumentUsingCommandWithSurrogatePairs() throws Exception {
+        try (IDocumentStore store = getDocumentStore()) {
+            String nameWithEmojis = "Marcin \uD83D\uDE21\uD83D\uDE21\uD83E\uDD2C\uD83D\uDE00";
+
+            User user = new User();
+            user.setName(nameWithEmojis);
+            user.setAge(31);
+
+            ObjectNode node = store.getConventions().getEntityMapper().valueToTree(user);
+
+            PutDocumentCommand command = new PutDocumentCommand("users/2", null, node);
+            store.getRequestExecutor().execute(command);
+
+            PutResult result = command.getResult();
+
+            assertThat(result.getId())
+                    .isEqualTo("users/2");
+
+            assertThat(result.getChangeVector())
+                    .isNotNull();
+
+            try (IDocumentSession session = store.openSession()) {
+                User loadedUser = session.load(User.class, "users/2");
+
+                assertThat(loadedUser.getName())
+                        .isEqualTo(nameWithEmojis);
+            }
+        }
+    }
 }
 

--- a/src/test/java/net/ravendb/client/infrastructure/AdminJsConsoleDatabaseOperation.java
+++ b/src/test/java/net/ravendb/client/infrastructure/AdminJsConsoleDatabaseOperation.java
@@ -43,7 +43,7 @@ public class AdminJsConsoleDatabaseOperation implements IMaintenanceOperation<Js
             HttpPost request = new HttpPost();
 
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.writeStartObject();
                     generator.writeFieldName("Script");
                     generator.writeString(_script);

--- a/src/test/java/net/ravendb/client/infrastructure/AdminJsConsoleOperation.java
+++ b/src/test/java/net/ravendb/client/infrastructure/AdminJsConsoleOperation.java
@@ -43,7 +43,7 @@ public class AdminJsConsoleOperation implements IServerOperation<JsonNode> {
             HttpPost request = new HttpPost();
 
             request.setEntity(new ContentProviderHttpEntity(outputStream -> {
-                try (JsonGenerator generator = mapper.getFactory().createGenerator(outputStream)) {
+                try (JsonGenerator generator = createSafeJsonGenerator(outputStream)) {
                     generator.writeStartObject();
                     generator.writeFieldName("Script");
                     generator.writeString(_script);


### PR DESCRIPTION
Surrogate pairs get mis-encoded by Jackson when it is responsible for the UTF-8 encoding.  When writing (via generator or mapper) to an `OutputStream` this can happen.  Writing to a wrapping `Writer` changes the responsibility to the writer and not Jackson which fixes the issue. 

Added a method in the base command class to create a safe generator, then a few additional fixes in areas that were not based on that command class.  A few areas are marked with TODO that are not clear if they need attention, since they call `writeValueToBytes` method which does the `OutputStream` problem internally.

See: https://github.com/FasterXML/jackson-core/issues/223