### PR TITLE
Remove a redundant null check.

### DIFF
--- a/src/main/java/net/ravendb/client/http/RequestExecutor.java
+++ b/src/main/java/net/ravendb/client/http/RequestExecutor.java
@@ -709,10 +709,6 @@ public class RequestExecutor implements CleanCloseable {
             requestRef.value = request;
         }
 
-        if (request == null) {
-            return;
-        }
-
         //noinspection SimplifiableConditionalExpression
         boolean noCaching = sessionInfo != null ? sessionInfo.isNoCaching() : false;
 


### PR DESCRIPTION
The RequestExecutor's execute method has a redunant null check.

Closes #60.