### PR TITLE
RDBC-905: Added support to MacOS

### DIFF
--- a/src/test/java/net/ravendb/client/driver/RavenTestDriver.java
+++ b/src/test/java/net/ravendb/client/driver/RavenTestDriver.java
@@ -369,8 +369,15 @@ public abstract class RavenTestDriver {
             }
         } else {
             Runtime runtime = Runtime.getRuntime();
+            String osName = System.getProperty("os.name").toLowerCase();
+            boolean isMacOs = osName.contains("mac") || osName.contains("darwin");
+
             try {
-                runtime.exec("xdg-open " + url);
+                if (isMacOs) {
+                    runtime.exec("open " + url);
+                } else {
+                    runtime.exec("xdg-open " + url);
+                }
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
Hello RavenDBers!

Accordingly to [this ticket](https://issues.hibernatingrhinos.com/issue/RDBC-905/Add-MacOS-support-for-waitForUserToContinueTheTest), I have added a simple snippet to identify if the running OS is MacOS or not. This is due this exception is thrown when running on MacOS:

```
java.io.IOException: Cannot run program "xdg-open": error=2, No such file or directory
java.lang.RuntimeException: java.io.IOException: Cannot run program "xdg-open": error=2, No such file or directory
    at net.ravendb.test.driver.RavenTestDriver.openBrowser(RavenTestDriver.java:258)
    at net.ravendb.test.driver.RavenTestDriver.waitForUserToContinueTheTest(RavenTestDriver.java:226)
    at RavenDBIntegrationTest.test(RavenDBIntegrationTest.java:55)
    at java.base/java.lang.reflect.Method.invoke(Method.java:580)
    at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
    at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
Caused by: java.io.IOException: Cannot run program "xdg-open": error=2, No such file or directory
    at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1170)
    at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1089)
    at java.base/java.lang.Runtime.exec(Runtime.java:681)
    at java.base/java.lang.Runtime.exec(Runtime.java:491)
    at java.base/java.lang.Runtime.exec(Runtime.java:366)
    at net.ravendb.test.driver.RavenTestDriver.openBrowser(RavenTestDriver.java:256)
    ... 5 more
Caused by: java.io.IOException: error=2, No such file or directory
    at java.base/java.lang.ProcessImpl.forkAndExec(Native Method)
    at java.base/java.lang.ProcessImpl.<init>(ProcessImpl.java:295)
    at java.base/java.lang.ProcessImpl.start(ProcessImpl.java:225)
    at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1126)
    ... 10 more
```

If you think this solution is too simple or not elegant, please let me know!