### PR TITLE
RDBC-905: fix macOS openBrowser via cmd function command

### DIFF
--- a/src/test/java/net/ravendb/client/driver/RavenTestDriver.java
+++ b/src/test/java/net/ravendb/client/driver/RavenTestDriver.java
@@ -371,7 +371,7 @@ public abstract class RavenTestDriver {
             Runtime runtime = Runtime.getRuntime();
             String osName = System.getProperty("os.name").toLowerCase();
             boolean isMacOs = osName.contains("mac") || osName.contains("darwin");
-
+            
             try {
                 if (isMacOs) {
                     runtime.exec("open " + url);

--- a/src/test/java/net/ravendb/client/driver/RavenTestDriver.java
+++ b/src/test/java/net/ravendb/client/driver/RavenTestDriver.java
@@ -371,7 +371,7 @@ public abstract class RavenTestDriver {
             Runtime runtime = Runtime.getRuntime();
             String osName = System.getProperty("os.name").toLowerCase();
             boolean isMacOs = osName.contains("mac") || osName.contains("darwin");
-            
+
             try {
                 if (isMacOs) {
                     runtime.exec("open " + url);

--- a/src/test/java/net/ravendb/client/test/issues/RDBC_905.java
+++ b/src/test/java/net/ravendb/client/test/issues/RDBC_905.java
@@ -3,9 +3,11 @@ package net.ravendb.client.test.issues;
 import net.ravendb.client.RemoteTestBase;
 import net.ravendb.client.documents.IDocumentStore;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 
 public class RDBC_905 extends RemoteTestBase {
 
+    @Disabled("Skipping test")
     @Test
     public void canOpenBrowserOnMacOs() throws Exception {
         try (IDocumentStore store = getDocumentStore()) {

--- a/src/test/java/net/ravendb/client/test/issues/RDBC_905.java
+++ b/src/test/java/net/ravendb/client/test/issues/RDBC_905.java
@@ -1,0 +1,15 @@
+package net.ravendb.client.test.issues;
+
+import net.ravendb.client.RemoteTestBase;
+import net.ravendb.client.documents.IDocumentStore;
+import org.junit.jupiter.api.Test;
+
+public class RDBC_905 extends RemoteTestBase {
+
+    @Test
+    public void canOpenBrowserOnMacOs() throws Exception {
+        try (IDocumentStore store = getDocumentStore()) {
+            waitForUserToContinueTheTest(store);
+        }
+    }
+}


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RDBC-905/Add-MacOS-support-for-waitForUserToContinueTheTest