### PR TITLE
RDBC-915: Add 7.1 to GHA RavenDB version matrix

### DIFF
--- a/.github/workflows/RavenClient.yml
+++ b/.github/workflows/RavenClient.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         java-version: [8, 11, 14, 16, 17, 21]
-        serverVersion: ["6.0", "6.2", "7.0"]
+        serverVersion: ["6.2", "7.0", "7.1"]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RDBC-915/Add-7.1-to-GHA-RavenDB-version-matrix-java