### PR TITLE
RDBC-945: un-required to specify ravendb_version to manual test git workflow

### DIFF
--- a/.github/workflows/RavenClient.yml
+++ b/.github/workflows/RavenClient.yml
@@ -11,7 +11,7 @@ on:
     inputs:
       ravendb_version:
         description: 'RavenDB Version'
-        required: true
+        required: false
         type: string
 
 jobs:


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RDBC-945/Make-ravendbversion-not-required-on-workflow