### PR TITLE
RDBC-988: Added v7.2 to GHA matrix

### DIFF
--- a/.github/workflows/RavenClient.yml
+++ b/.github/workflows/RavenClient.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         java-version: [8, 11, 14, 16, 17, 21]
-        serverVersion: ["6.2", "7.0", "7.1"]
+        serverVersion: ["6.2", "7.1", "7.2"]
       fail-fast: false
 
     env:


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RDBC-988/Add-7.2-to-GHA-RavenDB-version-matrix-java